### PR TITLE
Feature/non inclusion

### DIFF
--- a/contracts/implementation.sol
+++ b/contracts/implementation.sol
@@ -10,6 +10,10 @@ contract PatriciaTreeImplementation {
     constructor () public {
     }
 
+    function insert(bytes key, bytes value) public {
+        tree.insert(key, value);
+    }
+
     function get(bytes key) public view returns (bytes) {
         return tree.get(key);
     }
@@ -42,12 +46,21 @@ contract PatriciaTreeImplementation {
         return tree.getProof(key);
     }
 
+    function getNonInclusionProof(bytes key) public view returns (
+        bytes32 leafLabel,
+        bytes32 leafNode,
+        uint branchMask,
+        bytes32[] _siblings
+    ) {
+        return tree.getNonInclusionProof(key);
+    }
+
     function verifyProof(bytes32 rootHash, bytes key, bytes value, uint branchMask, bytes32[] siblings) public pure {
         PatriciaTree.verifyProof(rootHash, key, value, branchMask, siblings);
     }
 
-    function insert(bytes key, bytes value) public {
-        tree.insert(key, value);
+    function verifyNonInclusionProof(bytes32 rootHash, bytes key, bytes32 leafLabel, bytes32 leafNode, uint branchMask, bytes32[] siblings) public pure {
+        PatriciaTree.verifyNonInclusionProof(rootHash, key, leafLabel, leafNode, branchMask, siblings);
     }
 }
 
@@ -134,7 +147,7 @@ contract PatriciaTreeMerkleProof {
     }
 
     function seal() public onlyFor(Status.OPENED) {
-//        require(_verifyEdge(originalRootEdge));
+        //        require(_verifyEdge(originalRootEdge));
         tree.rootEdge = originalRootEdge;
         tree.root = PatriciaTree.edgeHash(tree.rootEdge);
         _changeStatus(Status.ONGOING);

--- a/contracts/implementation.sol
+++ b/contracts/implementation.sol
@@ -14,6 +14,14 @@ contract PatriciaTreeImplementation {
         return tree.get(key);
     }
 
+    function safeGet(bytes key) public view returns (bytes) {
+        return tree.safeGet(key);
+    }
+
+    function doesInclude(bytes key) public view returns (bool) {
+        return tree.doesInclude(key);
+    }
+
     function getValue(bytes32 hash) public view returns (bytes) {
         return tree.values[hash];
     }

--- a/contracts/tree.sol
+++ b/contracts/tree.sol
@@ -25,6 +25,18 @@ library PatriciaTree {
         return getValue(tree, _findNode(tree, key));
     }
 
+    function safeGet(Tree storage tree, bytes key) internal view returns (bytes value) {
+        bytes32 valueHash = _findNode(tree, key);
+        require(valueHash != bytes32(0));
+        value = getValue(tree, valueHash);
+        require(valueHash == keccak256(value));
+    }
+
+    function doesInclude(Tree storage tree, bytes key) internal view returns (bool) {
+        bytes32 valueHash = _findNode(tree, key);
+        return (valueHash != bytes32(0));
+    }
+
     function getValue(Tree storage tree, bytes32 valueHash) internal view returns (bytes) {
         return tree.values[valueHash];
     }

--- a/contracts/tree.sol
+++ b/contracts/tree.sol
@@ -109,6 +109,54 @@ library PatriciaTree {
         }
     }
 
+    function getNonInclusionProof(Tree storage tree, bytes key) internal view returns (
+        bytes32 potentialSiblingLabel,
+        bytes32 potentialSiblingValue,
+        uint branchMask,
+        bytes32[] _siblings
+    ){
+        uint length;
+        uint numSiblings;
+
+        // Start from root edge
+        D.Label memory label = D.Label(keccak256(key), 256);
+        D.Edge memory e = tree.rootEdge;
+        bytes32[256] memory siblings;
+
+        while (true) {
+            // Find at edge
+            require(label.length >= e.label.length);
+            D.Label memory prefix;
+            D.Label memory suffix;
+            (prefix, suffix) = Utils.splitCommonPrefix(label, e.label);
+
+            // suffix.length == 0 means that the key exists. Thus the length of the suffix should be not zero
+            require(suffix.length != 0);
+
+            if (prefix.length >= e.label.length) {
+                // Partial matched, keep finding
+                length += prefix.length;
+                branchMask |= uint(1) << (255 - length);
+                length += 1;
+                uint head;
+                (head, label) = Utils.chopFirstBit(suffix);
+                siblings[numSiblings++] = edgeHash(tree.nodes[e.node].children[1 - head]);
+                e = tree.nodes[e.node].children[head];
+            } else {
+                // Found the potential sibling. Set data to return
+                potentialSiblingLabel = e.label.data;
+                potentialSiblingValue = e.node;
+                break;
+            }
+        }
+        if (numSiblings > 0)
+        {
+            _siblings = new bytes32[](numSiblings);
+            for (uint i = 0; i < numSiblings; i++)
+                _siblings[i] = siblings[i];
+        }
+    }
+
     function verifyProof(bytes32 rootHash, bytes key, bytes value, uint branchMask, bytes32[] siblings) public pure {
         D.Label memory k = D.Label(keccak256(key), 256);
         D.Edge memory e;
@@ -120,6 +168,29 @@ library PatriciaTree {
             uint bit;
             (bit, e.label) = Utils.chopFirstBit(e.label);
             bytes32[2] memory edgeHashes;
+            edgeHashes[bit] = edgeHash(e);
+            edgeHashes[1 - bit] = siblings[siblings.length - i - 1];
+            e.node = keccak256(abi.encode(edgeHashes[0], edgeHashes[1]));
+        }
+        e.label = k;
+        require(rootHash == edgeHash(e));
+    }
+
+    function verifyNonInclusionProof(bytes32 rootHash, bytes key, bytes32 potentialSiblingLabel, bytes32 potentialSiblingValue, uint branchMask, bytes32[] siblings) public pure {
+        D.Label memory k = D.Label(keccak256(key), 256);
+        D.Edge memory e;
+        for (uint i = 0; branchMask != 0; i++) {
+            uint bitSet = Utils.lowestBitSet(branchMask);
+            branchMask &= ~(uint(1) << bitSet);
+            (k, e.label) = Utils.splitAt(k, 255 - bitSet);
+            uint bit;
+            (bit, e.label) = Utils.chopFirstBit(e.label);
+            bytes32[2] memory edgeHashes;
+            if (i == 0) {
+                e.label.length = bitSet;
+                e.label.data = potentialSiblingLabel;
+                e.node = potentialSiblingValue;
+            }
             edgeHashes[bit] = edgeHash(e);
             edgeHashes[1 - bit] = siblings[siblings.length - i - 1];
             e.node = keccak256(abi.encode(edgeHashes[0], edgeHashes[1]));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-patricia-tree",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-patricia-tree",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Patricia Tree solidity implemenation",
   "directories": {
     "test": "test"

--- a/test/PatriciaTree.test.js
+++ b/test/PatriciaTree.test.js
@@ -211,5 +211,30 @@ contract('PatriciaTree', async ([_, primary, nonPrimary]) => {
         assert.equal(web3.toUtf8(await tree.get('foo')), 'bar')
       })
     })
+
+    describe('safeGet()', async () => {
+      it('should return stored value for the given key', async () => {
+        await tree.insert('foo', 'bar', { from: primary })
+        assert.equal(web3.toUtf8(await tree.get('foo')), 'bar')
+      })
+      it('should throw if the given key is not included', async () => {
+        await tree.insert('foo', 'bar', { from: primary })
+        try {
+          await tree.get('fuz')
+          assert.fail('Did not reverted')
+        } catch (e) {
+          assert.ok('Reverted successfully')
+        }
+      })
+    })
+
+    describe('doesInclude()', async () => {
+      it('should return boolean whether the tree includes the given key or not', async () => {
+        await tree.insert('foo', 'bar', { from: primary })
+        assert.equal(await tree.doesInclude('foo'), true)
+        assert.equal(await tree.doesInclude('fuz'), false)
+      })
+    })
+
   })
 })


### PR DESCRIPTION
From 1.1.0, we can also verify non inclusion

# New functions
1. `safeGet()`
It guarantees the key-value existence
2. `doesInclude()`
You can check the key-value existence
3. `getNonInclusionProof()`
You can get data for non inclusion proof of a key
4. `verifyNonInclusionProof()`
You can check whether the key-value exists or not